### PR TITLE
Export `make` function

### DIFF
--- a/make.js
+++ b/make.js
@@ -31,11 +31,21 @@ function convert(data) {
 	write('postal-codes-simple.js', `module.exports=${JSON.stringify(ret2)}`);
 }
 
-if (input) {
-	convert(fs.readFileSync(input));
-} else {
-	(async () => {
-		const body = await got(POSTAL_CODE_URL).buffer();
-		convert(body);
-	})().catch(console.error);
+async function make() {
+	if (input) {
+		convert(fs.readFileSync(input));
+	} else {
+		try {
+			const body = await got(POSTAL_CODE_URL).buffer();
+			convert(body);
+		} catch (error) {
+			console.error(error);
+		}
+	}
+}
+
+module.exports = make;
+
+if (require.main === module) {
+	make();
 }


### PR DESCRIPTION
By exporting it, it's easier to manually use in a script. Currently since it's async and runs as a side effect of being `require`-ed we have to fake some waiting until the new files are written before checking of there are any new ones (we run a cron on CI checking if any new ones are available and update if so).

---

One potential option is to only support node 14.8+ and use ESM and TLA