### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,2 @@
-declare module "norway-postal-codes" {
-	const postalCodes: Record<string, string>;
-	export default postalCodes;
-}
+declare const norwayPostalCodes: Record<string, string>;
+export = norwayPostalCodes;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,5 @@
+/**
+ * An object with Norwegian postal codes as keys and the corresponding city names (capitalised) as values.
+ */
 declare const norwayPostalCodes: Record<string, string>;
 export = norwayPostalCodes;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare module "norway-postal-codes" {
-		const postalCodes: Record<string, string>;
-		export default postalCodes;
+	const postalCodes: Record<string, string>;
+	export default postalCodes;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
 declare module "norway-postal-codes" {
-  const postalCodes: Record<string, string>;
-
-  export default postalCodes;
+		const postalCodes: Record<string, string>;
+		export default postalCodes;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,14 @@
 /**
-An object with Norwegian postal codes as keys and the corresponding city names (capitalised) as values.
- */
+An object with Norway's postal codes as keys and the corresponding city names (uppercased) as values.
+
+@example
+```
+{
+	'1001': 'OSLO',
+	// …
+}
+```
+*/
 declare const norwayPostalCodes: Record<string, string>;
+
 export = norwayPostalCodes;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+declare module "norway-postal-codes" {
+  const postalCodes: Record<string, string>;
+
+  export default postalCodes;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * An object with Norwegian postal codes as keys and the corresponding city names (capitalised) as values.
+An object with Norwegian postal codes as keys and the corresponding city names (capitalised) as values.
  */
 declare const norwayPostalCodes: Record<string, string>;
 export = norwayPostalCodes;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"license": "MIT",
 	"repository": "sindresorhus/norway-postal-codes",
 	"funding": "https://github.com/sponsors/sindresorhus",
+	"types": "index.d.ts",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"license": "MIT",
 	"repository": "sindresorhus/norway-postal-codes",
 	"funding": "https://github.com/sponsors/sindresorhus",
-	"types": "index.d.ts",
 	"author": {
 		"name": "Sindre Sorhus",
 		"email": "sindresorhus@gmail.com",
@@ -22,7 +21,8 @@
 	},
 	"files": [
 		"make.js",
-		"converted/postal-codes-simple.js"
+		"converted/postal-codes-simple.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"norway",
@@ -40,6 +40,7 @@
 		"ava": "^2.4.0",
 		"xo": "^0.25.3"
 	},
+	"types": "index.d.ts",
 	"xo": {
 		"ignores": [
 			"converted/**"


### PR DESCRIPTION
Let's get some types up in here :)

This PR adds a simple `d.ts` file which declares the type of the postal code object to be `Record<string, string>`

I considered setting up a literal type for the entire postal code object, so that you have an object that is indexed by a set of literals, not just `Record<string, string>`, but I'm not sure how much value it really adds. 

Some devs may prefer not having to work with literals here, since in order to get a string out of the object you have to assert your string keys as index literals before indexing the postal code object:

```ts
    const postalCodes = (await import('norway-postal-codes')).default;

    let myPostalCode: string;

    const anyCity = postalCodes[myPostalCode]; // type is any

    if (myPostalCode in postalCodes) {
      const literalIndex = myPostalCode as keyof typeof postalCodes; // type is "1001" | "1003" | "1005" | etc.

      const stringCity = postalCodes[literalIndex]; // type is string
    }

```

On the other hand, such a type would certainly be preferable to `Record<string, string>` if your postal code is actually typed as a literal, not simply a string, for example if you have set up some kind of validation/sanitation pipeline. 

I think making such a type would work if we add this to `make.js`:
```js
	write(
		'index.d.ts',
		`declare module "norway-postal-codes" { export default ${JSON.stringify(
			ret2
		)}; }`
	);
```

What are your thoughts on typing this module?